### PR TITLE
Fix typo on LazyVim example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
   config = function()
     local ctactions = require("cheatsheet.telescope.actions")
     require("cheatsheet").setup({
-      bundled_cheetsheets = {
+      bundled_cheatsheets = {
         enabled = { "default", "lua", "markdown", "regex", "netrw", "unicode" },
         disabled = { "nerd-fonts" },
       },


### PR DESCRIPTION
"Fixes" #4 