### PR TITLE
docs: fix typo in Lazy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
   config = function()
     local ctactions = require("cheatsheet.telescope.actions")
     require("cheatsheet").setup({
-      bundled_cheetsheets = {
+      bundled_cheatsheets = {
         enabled = { "default", "lua", "markdown", "regex", "netrw", "unicode" },
         disabled = { "nerd-fonts" },
       },


### PR DESCRIPTION
The Lazy.nvim default config had a typo that breaks the config silently. the option `bundled_cheatsheets` is spelled `bundled_cheetsheets` with two 'e's. This fixes that.

Fixes #4 

This pull request includes a small change to the `README.md` file. The change corrects a typo in the configuration for `cheatsheet` setup.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R95): Fixed a typo by changing `bundled_cheetsheets` to `bundled_cheatsheets` in the configuration section.