### PR TITLE
Improved cheat copying and select or fill operation.

### DIFF
--- a/lua/cheatsheet/telescope/actions.lua
+++ b/lua/cheatsheet/telescope/actions.lua
@@ -42,7 +42,7 @@ local function select_current_item(prompt_bufnr, execute)
                 { "]: Press ", "" }, { cheat, "cheatCode" },
                 { " to ", "" },
                 { description:lower(), "cheatDescription" },
-            }, false, {}
+            }, true, {}
         )
     end
 end
@@ -59,9 +59,10 @@ function M.copy_cheat_value(prompt_bufnr)
     local selection = t_actions_state.get_selected_entry()
     local cheatcode = selection.value.cheatcode
     vim.fn.setreg("0", cheatcode)
+    vim.fn.setreg("*", cheatcode)
     vim.api.nvim_echo(
         { { "Yanked ", "" }, { cheatcode, "cheatCode" } },
-            false, {}
+            true, {}
     )
 end
 


### PR DESCRIPTION
I'm guessing a bit as to the plugin author's intentions, but for my use case I find the functions to copy the cheat and more tellingly the function to `select_or_fill_commandline` to be less than ideal. It seems the author intended the former to copy the cheat code for easy subsequent use but was copying only to the "0" register, which seems to copy only to the " register and not more clipboard friendly registers. I've changed this to include * as well. And in both cases I've changed the author's use of the `vim.api.nvim_echo` method to add to message history because the text doesn't appear anywhere at all if I don't. At least that way I can review it in the message history.